### PR TITLE
Human Security RTD Provider: initial release

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -80,6 +80,7 @@
       "greenbidsRtdProvider",
       "growthCodeRtdProvider",
       "hadronRtdProvider",
+      "humansecurityRtdProvider",
       "iasRtdProvider",
       "idWardRtdProvider",
       "imRtdProvider",

--- a/modules/humansecurityRtdProvider.js
+++ b/modules/humansecurityRtdProvider.js
@@ -24,7 +24,7 @@ import { loadExternalScript } from '../src/adloader.js';
  * @typedef {import('../modules/rtdModule/index.js').UserConsentData} UserConsentData
  */
 
-const SUBMODULE_NAME = 'humansecurityRtd';
+const SUBMODULE_NAME = 'humansecurity';
 const SCRIPT_URL = 'https://sonar.script.ac/prebid/rtd.js';
 
 const { logInfo, logWarn, logError } = prefixLog(`[${SUBMODULE_NAME}]:`);

--- a/modules/humansecurityRtdProvider.js
+++ b/modules/humansecurityRtdProvider.js
@@ -1,0 +1,145 @@
+/**
+ * This module adds humansecurity provider to the real time data module
+ *
+ * The {@link module:modules/realTimeData} module is required
+ * The module will inject the Human Security script into the context where Prebid.js is initialized, enriching bid requests with specific data to provide advanced protection against ad fraud and spoofing.
+ * @module modules/humansecurityRtdProvider
+ * @requires module:modules/realTimeData
+ */
+
+import { submodule } from '../src/hook.js';
+import {
+  logError,
+  mergeDeep,
+  generateUUID,
+  getWindowSelf,
+  getWindowLocation
+} from '../src/utils';
+import { getGlobal } from '../src/prebidGlobal';
+import { loadExternalScript } from '../src/adloader.js';
+
+/**
+ * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
+ * @typedef {import('../modules/rtdModule/index.js').SubmoduleConfig} SubmoduleConfig
+ * @typedef {import('../modules/rtdModule/index.js').UserConsentData} UserConsentData
+ */
+
+const SUBMODULE_NAME = 'humansecurity';
+const SCRIPT_URL = 'https://sonar.script.ac/prebid/rtd.js';
+const LOG_PREFIX = `[${SUBMODULE_NAME} RTD Submodule]:`;
+
+let enrichmentData = { hmns: { } };
+/**
+ * The function is used to update the 'enrichmentData' variable with the enrichment data from the injected script.
+ * @param {Object} data
+ */
+function updateEnrichmentData(data) {
+  if (!data.hmns || typeof data.hmns !== 'object')
+    return;
+
+  enrichmentData = mergeDeep({}, { hmns: data.hmns });
+}
+
+/**
+ * The function to be called upon module init.
+ * Injects the Human Security script into the page to provide ad fraud protection.
+ * @param {SubmoduleConfig} config
+ */
+function injectHumanSecurityScript(config) {
+  const sid = generateUUID();
+  const customerId = config?.params?.customerId;
+
+  const scriptOnloadHandler = function () {
+    const api = `${sid}_a`;
+    const wnd = getWindowSelf();
+    if (typeof wnd[api] === 'object' && typeof wnd[api].run === 'function')
+      wnd[api].run({ dependencyRef: getGlobal() }, updateEnrichmentData);
+  };
+  const scriptUrl = `${SCRIPT_URL}?h=${getWindowLocation().hostname}${customerId ? `&c=${customerId}` : ''}`;
+  const scriptAttributes = { 'data-sid': sid };
+
+  loadExternalScript(scriptUrl, SUBMODULE_NAME, scriptOnloadHandler, null, scriptAttributes);
+}
+
+/**
+ * The function to be called upon module init.
+ * If config parameters are passed, the function validates them and throws an error if they are incorrectly provided.
+ * @param {SubmoduleConfig} config
+ */
+function readConfig(config) {
+  if (!config.params)
+    return;
+
+  if (config.params.customerId && typeof config.params.customerId !== 'string') {
+    throw new Error(`${LOG_PREFIX} If specified, the 'customerId' parameter in the module configuration must be a string.`);
+  }
+
+  if (config.params.bidders) {
+    if (!Array.isArray(config.params.bidders)) {
+      throw new Error(`${LOG_PREFIX} If specified, the 'bidders' parameter in the module configuration must be an array.`);
+    }
+
+    if (config.params.bidders.length === 0) {
+      throw new Error(`${LOG_PREFIX} If specified, the 'bidders' parameter array in the module configuration must contain at least one bidder code.`)
+    }
+  }
+}
+
+/**
+ * onGetBidRequestData is called once per auction.
+ * Update the `ortb2Fragments` object with the data from the injected script.
+ *
+ * @param {Object} reqBidsConfigObj
+ * @param {function} callback
+ * @param {SubmoduleConfig} config
+ * @param {UserConsentData} userConsent
+ */
+function onGetBidRequestData(reqBidsConfigObj, callback, config, userConsent) {
+  const fragment = { ext: enrichmentData };
+  if (!config.params || !config.params.bidders) {
+    mergeDeep(reqBidsConfigObj.ortb2Fragments.global, fragment);
+  } else {
+    config.params.bidders.forEach((bidderCode) => {
+      mergeDeep(reqBidsConfigObj.ortb2Fragments.bidder, { [bidderCode]: fragment });
+    });
+  }
+  callback();
+}
+
+/**
+ * The function which performs submodule registration.
+ */
+function registerHumanMediaGuardSubmodule() {
+  submodule('realTimeData', /** @type {RtdSubmodule} */ ({
+    name: SUBMODULE_NAME,
+
+    init: (config, userConsent) => {
+      try {
+        readConfig(config);
+        injectHumanSecurityScript(config);
+
+        return true;
+      } catch (err) {
+        logError(LOG_PREFIX, err.message);
+        return false;
+      }
+    },
+    getBidRequestData: onGetBidRequestData
+  }));
+}
+
+/**
+ * Exporting local (and otherwise encapsulated to this module) functions
+ * for testing purposes
+ */
+export const __TEST__ = {
+  SUBMODULE_NAME,
+  SCRIPT_URL,
+  updateEnrichmentData,
+  onGetBidRequestData,
+  readConfig,
+  injectHumanSecurityScript,
+  registerHumanMediaGuardSubmodule
+}
+
+registerHumanMediaGuardSubmodule();

--- a/modules/humansecurityRtdProvider.js
+++ b/modules/humansecurityRtdProvider.js
@@ -154,11 +154,11 @@ function onImplMessage(msg) {
  * @param {UserConsentData} userConsent
  */
 function onGetBidRequestData(reqBidsConfigObj, callback, config, userConsent) {
-  // Add ext.hmns to the global ORTB data for all vendors to use
-  // At the time of writing this submodule, ext.hmns is an object defined
+  // Add device.ext.hmns to the global ORTB data for all vendors to use
+  // At the time of writing this submodule, "hmns" is an object defined
   // internally by humansecurity, and it currently contains "v1" field
   // with a token that contains collected signals about this session.
-  mergeDeep(reqBidsConfigObj.ortb2Fragments.global, { ext: { hmns: hmnsData } });
+  mergeDeep(reqBidsConfigObj.ortb2Fragments.global, { device: { ext: { hmns: hmnsData } } });
   callback();
 }
 

--- a/modules/humansecurityRtdProvider.md
+++ b/modules/humansecurityRtdProvider.md
@@ -6,12 +6,13 @@ Module Type: Rtd Provider
 Maintainer: alexey@humansecurity.com
 ```
 
-The Human Security RTD submodule offers pre-bid signal collection, aimed to improve real-time protection against all sorts of invalid traffic, such as
-bot-generated ad interactions or sophisticated ad fraud schemes. It generates Human Security token, which then can be consumed by vendors,
-sent within bid requests, and used for bot detection on the backend.
+The Human Security RTD submodule offers pre-bid signal collection, aimed to improve real-time protection
+against all sorts of invalid traffic, such as bot-generated ad interactions or sophisticated ad fraud schemes.
+It generates Human Security token, which then can be consumed by vendors, sent within bid requests,
+and used for bot detection on the backend.
 
 
-## Build
+# Build
 First, make sure to add the Human Security submodule to your Prebid.js package with:
 
 ```bash
@@ -20,9 +21,10 @@ gulp build --modules="rtdModule,humansecurityRtdProvider,..."
 
 > `rtdModule` is a required module to use Human Security RTD module.
 
-## Configuration
+# Configuration
 
-Please refer to [Prebid Documentation](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-realTimeData) on RTD module configuration for details on required and optional parameters of `realTimeData`
+Please refer to [Prebid Documentation](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-realTimeData)
+on RTD module configuration for details on required and optional parameters of `realTimeData`
 
 This module is configured as part of the `realTimeData.dataProviders` object.
 ```javascript
@@ -43,3 +45,51 @@ Parameters:
 
 * `clientId` - optional, string. Should you need advanced reporting, contact prebid@humansecurity.com to receive client ID.
 * `verbose` - optional, boolean. Only set to `true` if troubleshooting issues.
+
+
+# Notes
+
+## Rationale
+
+Historically, IVT protection is achieved via dropping analytics scripts and/or pixels in the ads, which enriches impression
+data with collected signals. Those signals, when analyzed by IVT protection vendors, allow distinguishing valid from invalid
+traffic, but only retroactively - after the impression was served, and all the participant infrastructures has already
+participated in serving the request. This not only leads to unnecessary infrastructure costs, but to uncomfortable processes
+of reimbursement, or clawback.
+
+MediaGuard from HUMAN solves this problem by making predictions at pre-bid stage on whether the traffic is fradulent, allowing
+the platforms to knowingly not participate in the IVT-generated auctions.
+
+However, the challenge in making those predictions is that it has to primarily rely on historical data, which introduces lag,
+and typically might be less accurate, than direct decision making using the high-quality signals obtained from the pixels
+and/or JS analytics scripts delivered in the ads.
+
+This is where this RTD submodule bridges the gap by facilitating the very same signal collection that is typically performed
+post-bid, and makes the signals available during bidding.
+
+## Operation model
+
+Together, the data flow looks like this:
+
+* Prebid.js gets initialized, including HUMAN RTD submodule.
+* Submodule loads the signal collection implementation script from high-performance, low latency endpoint.
+* This script starts collecting the signals, and makes them available to the RTD submodule as soon as possible.
+* The RTD submodule places the collected signals into the ORTB structure for bid adapters to pick up.
+* Bid adapters are expected to retrieve `ortb2.ext.hmns` object and incorporate it into their bid requests.
+* Bid requests having `ortb2.ext.hmns` data allow their backend to make more informative requests to HUMAN MediaGuard.
+    * Should bid requests be passed to other platforms during the bidding process, it's encouraged to keep `ortb2.ext.hmns`
+      so that, for example, a downstream DSP can also has have this data passed to Human.
+* HUMAN MediaGuard uses the additional high-quality signal from `ortb2.ext.hmns`, and provides IVT classification response
+  with improved quality and accuracy.
+
+
+## Remarks on the collected signals
+
+There are a few points that are worth being mentioned separately, to avoid confusion and suspicion:
+
+* The nature of the collected signals is *exactly the same* as those already collected in analytics scripts that arrive in the ads.
+* The signals themselves are even less verbose than those HUMAN collects post-bid, because of timing / performance requirements.
+* No signals attempt to *identify* users, their only purpose is to classify traffic into valid / invalid.
+* The signal collection script is external to Prebid.js, so that it can be constantly kept up to date with ever-evolving browser
+  nature without the publishers having to re-build their Prebid.js frequently.
+  * It's also obfuscated, as all similar scripts in the industry are, which is something that cannot be accommodated by Prebid.js.

--- a/modules/humansecurityRtdProvider.md
+++ b/modules/humansecurityRtdProvider.md
@@ -1,7 +1,7 @@
 # Overview
 
 ```
-Module Name: Human Security Rtd provider
+Module Name: HUMAN Security Rtd provider
 Module Type: Rtd Provider
 Maintainer: alexey@humansecurity.com
 ```
@@ -14,7 +14,7 @@ such as bot-generated ad interactions or sophisticated ad fraud schemes.
 
 ## How does it work?
 
-HUMAN Security RTD submodule generates a HUMAN Security token, which then can be consumed by vendors,
+HUMAN Security RTD submodule generates a HUMAN Security token, which then can be consumed by adapters,
 sent within bid requests, and used for bot detection on the backend.
 
 ## Key Facts about the HUMAN Security RTD Submodule
@@ -29,13 +29,14 @@ sent within bid requests, and used for bot detection on the backend.
 
 
 # Build
-First, make sure to add the Human Security submodule to your Prebid.js package with:
+
+First, make sure to add the HUMAN Security submodule to your Prebid.js package with:
 
 ```bash
-gulp build --modules="rtdModule,humansecurityRtdProvider,..."
+gulp build --modules="rtdModule,humansecurity,..."
 ```
 
-> `rtdModule` is a required module to use Human Security RTD module.
+> `rtdModule` is a required module to use HUMAN Security RTD module.
 
 
 # Configuration
@@ -76,7 +77,6 @@ pbjs.setConfig({
 
 ## Supported parameters
 
-{: .table .table-bordered .table-striped }
 | Name             |Type           | Description                                                         | Required |
 | :--------------- | :------------ | :------------------------------------------------------------------ |:---------|
 | `clientId`  | String | Should you need advanced reporting, contact [prebid@humansecurity.com](prebid@humansecurity.com) to receive client ID. | No |
@@ -99,8 +99,8 @@ of type `ERROR`. With `verbose` parameter set to `true`, it may additionally:
 Example output of the latency information:
 
 ```
-INFO: [HUMANsecurity]: impl JS time to init (ms): 6.
-INFO: [HUMANsecurity]: impl JS time to collect (ms): 13.
+INFO: [humansecurity]: impl JS time to init (ms): 6.
+INFO: [humansecurity]: impl JS time to collect (ms): 13.
 ```
 
 Here, the two reported metrics are how much time the signal collection script spent blocking on initialization,

--- a/modules/humansecurityRtdProvider.md
+++ b/modules/humansecurityRtdProvider.md
@@ -1,0 +1,48 @@
+# Overview
+
+```
+Module Name: Human Security Rtd provider
+Module Type: Rtd Provider
+Maintainer: mykyta.kikot@humansecurity.com
+```
+
+The Human Security RTD submodule offers a comprehensive defense against ad fraud and bot traffic for publishers. 
+It ensures real-time protection by blocking invalid traffic, detecting and preventing bot-generated ad interactions, and safeguarding ad inventory from sophisticated fraud schemes.
+
+
+## Build
+First, make sure to add the Human Security submodule to your Prebid.js package with:
+
+```bash
+gulp build --modules="rtdModule,humansecurityRtdProvider,..."  
+```
+
+> `rtdModule` is a required module to use Human Security RTD module.
+
+## Configuration
+
+Please refer to [Prebid Documentation](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-realTimeData) on RTD module configuration for details on required and optional parameters of `realTimeData`
+
+This module is configured as part of the `realTimeData.dataProviders` object.
+```javascript
+pbjs.setConfig({
+    realTimeData: {
+        dataProviders: [{
+            name: 'humansecurity',
+            params: {
+                clientId: 'ABC123', // optional, can be omitted
+                bidders: ['appnexus'], // optional, can be omitted
+            }
+        }]
+    }
+});
+```
+
+## Configuration parameters
+
+#### `clientId` - Optional, string
+- The client ID is provided by Human Security only for specific clients. 
+
+#### `bidders` - Optional, Array<string>
+- When this parameter is included, it should be an array of strings that correspond to the bidder codes of the Prebid adapters, the ortb2 object of which will be modified. 
+If this parameter is not included, the RTD module will default to updating the ortb2 object for all bid adapters used on the page.

--- a/modules/humansecurityRtdProvider.md
+++ b/modules/humansecurityRtdProvider.md
@@ -3,7 +3,7 @@
 ```
 Module Name: Human Security Rtd provider
 Module Type: Rtd Provider
-Maintainer: mykyta.kikot@humansecurity.com
+Maintainer: alexey@humansecurity.com
 ```
 
 The Human Security RTD submodule offers pre-bid signal collection, aimed to improve real-time protection against all sorts of invalid traffic, such as
@@ -29,7 +29,7 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 pbjs.setConfig({
     realTimeData: {
         dataProviders: [{
-            name: 'humansecurityRtd',
+            name: 'humansecurity',
             params: {
                 clientId: 'ABC123', // optional, can be omitted
                 verbose: true, // optional, should be false in production
@@ -41,5 +41,5 @@ pbjs.setConfig({
 
 Parameters:
 
-* `clientId` - optional, string. Contact Human Security to receive client ID if you need advanced reporting.
+* `clientId` - optional, string. Should you need advanced reporting, contact prebid@humansecurity.com to receive client ID.
 * `verbose` - optional, boolean. Only set to `true` if troubleshooting issues.

--- a/modules/humansecurityRtdProvider.md
+++ b/modules/humansecurityRtdProvider.md
@@ -6,15 +6,16 @@ Module Type: Rtd Provider
 Maintainer: mykyta.kikot@humansecurity.com
 ```
 
-The Human Security RTD submodule offers a comprehensive defense against ad fraud and bot traffic for publishers. 
-It ensures real-time protection by blocking invalid traffic, detecting and preventing bot-generated ad interactions, and safeguarding ad inventory from sophisticated fraud schemes.
+The Human Security RTD submodule offers pre-bid signal collection, aimed to improve real-time protection against all sorts of invalid traffic, such as
+bot-generated ad interactions or sophisticated ad fraud schemes. It generates Human Security token, which then can be consumed by vendors,
+sent within bid requests, and used for bot detection on the backend.
 
 
 ## Build
 First, make sure to add the Human Security submodule to your Prebid.js package with:
 
 ```bash
-gulp build --modules="rtdModule,humansecurityRtdProvider,..."  
+gulp build --modules="rtdModule,humansecurityRtdProvider,..."
 ```
 
 > `rtdModule` is a required module to use Human Security RTD module.
@@ -28,21 +29,17 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 pbjs.setConfig({
     realTimeData: {
         dataProviders: [{
-            name: 'humansecurity',
+            name: 'humansecurityRtd',
             params: {
                 clientId: 'ABC123', // optional, can be omitted
-                bidders: ['appnexus'], // optional, can be omitted
+                verbose: true, // optional, should be false in production
             }
         }]
     }
 });
 ```
 
-## Configuration parameters
+Parameters:
 
-#### `clientId` - Optional, string
-- The client ID is provided by Human Security only for specific clients. 
-
-#### `bidders` - Optional, Array<string>
-- When this parameter is included, it should be an array of strings that correspond to the bidder codes of the Prebid adapters, the ortb2 object of which will be modified. 
-If this parameter is not included, the RTD module will default to updating the ortb2 object for all bid adapters used on the page.
+* `clientId` - optional, string. Contact Human Security to receive client ID if you need advanced reporting.
+* `verbose` - optional, boolean. Only set to `true` if troubleshooting issues.

--- a/modules/humansecurityRtdProvider.md
+++ b/modules/humansecurityRtdProvider.md
@@ -6,10 +6,26 @@ Module Type: Rtd Provider
 Maintainer: alexey@humansecurity.com
 ```
 
-The Human Security RTD submodule offers pre-bid signal collection, aimed to improve real-time protection
-against all sorts of invalid traffic, such as bot-generated ad interactions or sophisticated ad fraud schemes.
-It generates Human Security token, which then can be consumed by vendors, sent within bid requests,
-and used for bot detection on the backend.
+## What is it?
+
+The HUMAN Security RTD submodule offers publishers a mechanism to integrate pre-bid signal collection
+for the purpose of providing real-time protection against all sorts of invalid traffic,
+such as bot-generated ad interactions or sophisticated ad fraud schemes.
+
+## How does it work?
+
+HUMAN Security RTD submodule generates a HUMAN Security token, which then can be consumed by vendors,
+sent within bid requests, and used for bot detection on the backend.
+
+## Key Facts about the HUMAN Security RTD Submodule
+
+* Enriches bid requests with IVT signal, historically done post-bid
+* No incremental signals collected beyond existing HUMAN post-bid solution
+* Offsets negative impact from loss of granularity in IP and User Agent at bid time
+* Does not expose collected IVT signal to any party who doesn’t otherwise already have access to the same signal collected post-bid
+* Does not introduce meaningful latency, as demonstrated in the Latency section
+* Comes at no additional cost to collect IVT signal and make it available at bid time
+* Leveraged to differentiate the invalid bid requests at device level, and cannot be used to identify a user or a device, thus preserving privacy.
 
 
 # Build
@@ -21,75 +37,194 @@ gulp build --modules="rtdModule,humansecurityRtdProvider,..."
 
 > `rtdModule` is a required module to use Human Security RTD module.
 
+
 # Configuration
 
-Please refer to [Prebid Documentation](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-realTimeData)
-on RTD module configuration for details on required and optional parameters of `realTimeData`
-
 This module is configured as part of the `realTimeData.dataProviders` object.
+Please refer to [Prebid Documentation](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-realTimeData)
+on RTD module configuration for details on required and optional parameters of `realTimeData`.
+
+By default, using this submodule *does not require any prior communication with HUMAN, nor any special configuration*,
+besides just indicating that it should be loaded:
+
+```javascript
+pbjs.setConfig({
+    realTimeData: {
+        dataProviders: [{
+            name: 'humansecurity'
+        }]
+    }
+});
+```
+
+It can be optionally parameterized, for example, to include client ID obtained from HUMAN,
+should any advanced reporting be needed, or to have verbose output for troubleshooting:
+
 ```javascript
 pbjs.setConfig({
     realTimeData: {
         dataProviders: [{
             name: 'humansecurity',
             params: {
-                clientId: 'ABC123', // optional, can be omitted
-                verbose: true, // optional, should be false in production
+                clientId: 'ABC123',
+                verbose: true
             }
         }]
     }
 });
 ```
 
-Parameters:
+## Supported parameters
 
-* `clientId` - optional, string. Should you need advanced reporting, contact prebid@humansecurity.com to receive client ID.
-* `verbose` - optional, boolean. Only set to `true` if troubleshooting issues.
+{: .table .table-bordered .table-striped }
+| Name             |Type           | Description                                                         | Required |
+| :--------------- | :------------ | :------------------------------------------------------------------ |:---------|
+| `clientId`  | String | Should you need advanced reporting, contact [prebid@humansecurity.com](prebid@humansecurity.com) to receive client ID. | No |
+| `verbose`   | Boolean | Only set to `true` if troubleshooting issues. | No |
 
+
+## Logging, latency and troubleshooting
+
+The optional `verbose` parameter can be especially helpful to troubleshoot any issues and/or monitor latency.
+
+By default, the submodule may, in case of unexpected issues, invoke `logError`, emitting `auctionDebug` events
+of type `ERROR`. With `verbose` parameter set to `true`, it may additionally:
+
+* Call `logWarning`, resulting in `auctionDebug` events of type `WARNING`,
+* Call `logInfo` with latency information.
+    * To observe these messages in console, Prebid.js must be run in
+      [debug mode](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#debugging) -
+      either by adding `?pbjs_debug=true` to your page's URL, or by configuring with `pbjs.setConfig({ debug: true });`
+
+Example output of the latency information:
+
+```
+INFO: [HUMANsecurity]: impl JS time to init (ms): 6.
+INFO: [HUMANsecurity]: impl JS time to collect (ms): 13.
+```
+
+Here, the two reported metrics are how much time the signal collection script spent blocking on initialization,
+and the total time required to obtain the signals, respectively. Note that "time to collect" metric accounts
+for all the time spent since the script has started initializing until the signals were made available to the bidders,
+therefore it includes "time to init", and typically some non-blocking time spent waiting for signals. Only “time to init” is blocking.
+
+
+# How can I contribute?
+
+Prebid has launched a Measurement Taskforce to address signal deprecation and measurement in the current environment,
+which has become a publisher-level issue. Without a solution, granularity of measurement disappears.
+If you would like to participate to help identify and develop solutions to these problems such as the one tackled
+by this submodule, please consider joining the Measurement Taskforce (see https://prebid.org/project-management-committees/).
 
 # Notes
 
-## Rationale
-
-Historically, IVT protection is achieved via dropping analytics scripts and/or pixels in the ads, which enriches impression
-data with collected signals. Those signals, when analyzed by IVT protection vendors, allow distinguishing valid from invalid
-traffic, but only retroactively - after the impression was served, and all the participant infrastructures has already
-participated in serving the request. This not only leads to unnecessary infrastructure costs, but to uncomfortable processes
-of reimbursement, or clawback.
-
-MediaGuard from HUMAN solves this problem by making predictions at pre-bid stage on whether the traffic is fradulent, allowing
-the platforms to knowingly not participate in the IVT-generated auctions.
-
-However, the challenge in making those predictions is that it has to primarily rely on historical data, which introduces lag,
-and typically might be less accurate, than direct decision making using the high-quality signals obtained from the pixels
-and/or JS analytics scripts delivered in the ads.
-
-This is where this RTD submodule bridges the gap by facilitating the very same signal collection that is typically performed
-post-bid, and makes the signals available during bidding.
 
 ## Operation model
 
-Together, the data flow looks like this:
+Following is the expected data flow:
 
-* Prebid.js gets initialized, including HUMAN RTD submodule.
-* Submodule loads the signal collection implementation script from high-performance, low latency endpoint.
+* Prebid.js gets initialized, including the HUMAN RTD submodule.
+* The submodule loads the signal collection implementation script from a high-performance, low latency endpoint.
 * This script starts collecting the signals, and makes them available to the RTD submodule as soon as possible.
 * The RTD submodule places the collected signals into the ORTB structure for bid adapters to pick up.
-* Bid adapters are expected to retrieve `ortb2.ext.hmns` object and incorporate it into their bid requests.
-* Bid requests having `ortb2.ext.hmns` data allow their backend to make more informative requests to HUMAN MediaGuard.
-    * Should bid requests be passed to other platforms during the bidding process, it's encouraged to keep `ortb2.ext.hmns`
-      so that, for example, a downstream DSP can also has have this data passed to Human.
-* HUMAN MediaGuard uses the additional high-quality signal from `ortb2.ext.hmns`, and provides IVT classification response
-  with improved quality and accuracy.
+* Bid adapters are expected to retrieve the `ortb2.device.ext.hmns` object and incorporate it into their bid requests.
+* Bid requests having the `ortb2.device.ext.hmns` data allow their backend to make more informative requests to HUMAN Ad Fraud Defense.
+    * Should bid requests be passed to other platforms during the bidding process, adapter developers are
+      encouraged to keep `ortb2.device.ext.hmns` so that, for example, a downstream DSP can also have this data passed to HUMAN.
 
 
 ## Remarks on the collected signals
 
-There are a few points that are worth being mentioned separately, to avoid confusion and suspicion:
+There are a few points that are worth being mentioned separately, to avoid confusion and unnecessary suspicion:
 
-* The nature of the collected signals is *exactly the same* as those already collected in analytics scripts that arrive in the ads.
-* The signals themselves are even less verbose than those HUMAN collects post-bid, because of timing / performance requirements.
-* No signals attempt to *identify* users, their only purpose is to classify traffic into valid / invalid.
-* The signal collection script is external to Prebid.js, so that it can be constantly kept up to date with ever-evolving browser
-  nature without the publishers having to re-build their Prebid.js frequently.
-  * It's also obfuscated, as all similar scripts in the industry are, which is something that cannot be accommodated by Prebid.js.
+* The nature of the collected signals is exactly the same as those already collected in analytics scripts
+  that arrive in the ads via existing post-bid processes.
+* The signals themselves are even less verbose than those HUMAN normally collects post-bid, because of timing / performance requirements.
+* No signals attempt to identify users. Their only purpose is to classify traffic into valid / invalid.
+* The signal collection script is external to Prebid.js. This ensures that it can be constantly kept up to date with
+  the ever-evolving nature of the threat landscape without the publishers having to rebuild their Prebid.js frequently.
+    * The signal collection script is also obfuscated, as a defense-in-depth measure in order to complicate tampering by
+      bad actors, as are all similar scripts in the industry, which is something that cannot be accommodated by Prebid.js itself.
+
+## Why is this approach an innovation?
+
+Historically, IVT protection is achieved via dropping analytics scripts and/or pixels in the ads, which enriches impression data with collected signals.
+Those signals, when analyzed by IVT protection vendors, allow distinguishing valid from invalid traffic, but only retroactively -
+after the impression was served, and all the participant infrastructures have already participated in serving the request.
+
+This not only leads to unnecessary infrastructure costs, but to uncomfortable and often difficult processes of reconciliation
+and reimbursement, or claw-back. When handled only at the post-bid stage, the true bad actors have already achieved their objectives,
+and legitimate advertisers, platforms, and publishers are left holding the bag.
+
+HUMAN’s Ad Fraud Defense solves this problem by making predictions at the pre-bid stage about whether the traffic is fraudulent,
+allowing the platforms to knowingly not participate in the IVT-generated auctions.
+
+However, the challenge in making those predictions is that even these prebid predictions rely primarily on historical data,
+which not only introduces lag, but typically might be less accurate than direct decision making (were it possible) using
+the high-quality signals obtained from the pixels and/or JS analytics scripts delivered in the ads.
+
+The HUMAN Security RTD submodule bridges the gap by introducing a new innovation: it **facilitates the very same signal
+collection that is typically performed post-bid, but at the pre-bid stage, and makes the signals available during bidding.**
+This not only permits for accurate invalid traffic detection at the earliest stages of the auction process, but diminishes
+the impacts of signal deprecation such as the loss of IP and User Agent on effective fraud mitigation.
+
+
+## Why is this good for publishers?
+
+In the process of Invalid Traffic reconciliation, publishers are often the last to know, as they are informed by their downstream
+partners that the inventory they had provided in good faith has been detected as invalid traffic. This is most painful when it
+happens via post-bid detection when publishers are often the last party in the chain from whom the others can collect clawbacks,
+and the publishers themselves are left with little recourse. And when invalid traffic is blocked by platforms prebid, it is after
+the fact of publishers having sent out bid requests, thus harming fill rates, revenue opportunities, and overall auction and bidding
+efficiencies. And of course, invalid traffic whether detected post-bid or pre-bid is damaging to the publisher’s reputation
+with its demand partners.
+
+The HUMAN Security RTD submodule creates a more efficient integration for the process of invalid traffic mitigation.
+Invalid traffic detection and filtration is being done already with or without the participation of publishers, and measurement
+will be done on the ad inventory because advertisers need it to manage their own ad spend. The HUMAN Security RTD submodule gives
+publishers a direct seat, and in fact the first seat, in the invalid traffic detection process, allowing it to be done effectively,
+directly, and in a way that provides the publisher with more direct insight.
+
+Existing models of signal deprecation suggest that IP protection is going to be 100 times or more less granular.
+This would normally be expected to significantly reduce the ability to do prebid publisher-side predictions. This in turn would prevent
+the ability to see if specific impressions are bad and instead potentially result in the whole publisher being identified as being
+invalid traffic by a buyer. It is important to note that the purpose of data collection by the HUMAN Security RTD submodule is
+specifically for invalid traffic detection and filtration. It will not be used for unrelated and unauthorized purposes
+like targeting audiences, etc.
+
+The HUMAN Security RTD submodule makes sure to have the best integration possible to avoid revenue loss.
+It will help publishers avoid painful clawbacks. Currently, clawbacks are based on opaque measurement processes downstream from
+publishers where the information is controlled and withheld. The HUMAN Security RTD submodule will make publishers a more direct
+party to the measurement and verification process and help make sure the origin and the recipient match.
+
+Importantly, the effective use of the HUMAN Security RTD submodule signifies to SSPs and buyers that the publisher
+is a joint partner in ensuring quality ad delivery, and demonstrates that the publisher is a premium supply source.
+
+Finally, the HUMAN Security RTD submodule sets the ecosystem up for a future where publisher level reporting is facilitated.
+This will allow for increased transparency about what is happening with publisher inventory, further enhancing and
+ensuring the value of the inventory.
+
+## FAQ
+
+### Is latency an issue?
+
+The HUMAN Security RTD submodule is designed to minimize any latency in the auction within normal SLAs.
+
+### Do publishers get any insight into how the measurement is judged?
+
+Having the The HUMAN Security RTD submodule be part of the prebid process will allow the publisher to have insight
+into the invalid traffic metrics as they are determined and provide confidence that they are delivering quality
+inventory to the buyer.
+
+### How are privacy concerns addressed?
+
+The HUMAN Security RTD submodule seeks to reduce the impacts from signal deprecation that are inevitable without
+compromising privacy by avoiding re-identification. Each bid request is enriched with just enough signal
+to identify if the traffic is invalid or not.
+
+By having the The HUMAN Security RTD submodule operate at the Prebid level, data can be controlled
+and not as freely passed through the bidstream where it may be accessible to various unknown parties.
+
+Note: anti-fraud use cases typically have carve outs in laws and regulations to permit data collection
+essential for effective fraud mitigation, but this does not constitute legal advice and you should
+consult your attorney when making data access decisions.

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -20,6 +20,7 @@ const _approvedLoadExternalJSList = [
   'browsi',
   'brandmetrics',
   'clean.io',
+  'humansecurity',
   'confiant',
   'contxtful',
   'hadron',

--- a/test/spec/modules/humansecurityRtdProvider_spec.js
+++ b/test/spec/modules/humansecurityRtdProvider_spec.js
@@ -1,159 +1,206 @@
 import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
+
 import * as utils from '../../../src/utils.js';
 import * as hook from '../../../src/hook.js';
+import * as refererDetection from '../../../src/refererDetection.js';
 
 import { __TEST__ } from '../../../modules/humansecurityRtdProvider.js';
 
 const {
   SUBMODULE_NAME,
   SCRIPT_URL,
-  updateEnrichmentData,
-  onGetBidRequestData,
-  readConfig,
-  injectHumanSecurityScript,
-  registerHumanMediaGuardSubmodule
+  main,
+  load,
+  onImplLoaded,
+  onImplMessage,
+  onGetBidRequestData
 } = __TEST__;
 
 describe('humansecurity RTD module', function () {
   let sandbox;
-  let ortb2Stub;
 
-  const win = Object.create({}, {
-    hostname: { value: 'example.com' }
-  });
-  const reqBidsConfig = {
-    ortb2Fragments: {
-      bidder: {},
-      global: {}
-    }
-  };
+  const stubUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const sonarStubId = `sonar_${stubUuid}`;
+  const stubWindow = { [sonarStubId]: undefined };
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
-    sandbox.stub(utils, 'getWindowLocation').returns(win);
-    sandbox.stub(utils, 'getWindowSelf').returns(win);
-    sandbox.stub(utils, 'generateUUID').returns('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
-
-    ortb2Stub = sandbox.stub(reqBidsConfig, 'ortb2Fragments').value({bidder: {}, global: {}});
+    sandbox.stub(utils, 'getWindowSelf').returns(stubWindow);
+    sandbox.stub(utils, 'generateUUID').returns(stubUuid);
+    sandbox.stub(refererDetection, 'getRefererInfo').returns({ domain: 'example.com' });
   });
   afterEach(function() {
     sandbox.restore();
   });
 
-  describe('Module initialization step', function () {
+  describe('Initialization step', function () {
+    let sandbox2;
+    let connectSpy;
+    beforeEach(function() {
+      sandbox2 = sinon.sandbox.create();
+      connectSpy = sandbox.spy();
+      // Once the impl script is loaded, it registers the API using session ID
+      sandbox2.stub(stubWindow, sonarStubId).value({ connect: connectSpy });
+    });
+    afterEach(function () {
+      sandbox2.restore();
+    });
+
     it('should accept valid configurations', function () {
-      expect(() => readConfig({})).to.not.throw();
-      expect(() => readConfig({ params: {} })).to.not.throw();
-      expect(() => readConfig({ params: { bidders: ['bidderCode'] } })).to.not.throw();
-      expect(() => readConfig({ params: { customerId: 'ABC123' } })).to.not.throw();
+      // Default configuration - empty
+      expect(() => load({})).to.not.throw();
+      expect(() => load({ params: {} })).to.not.throw();
+      // Configuration with clientId
+      expect(() => load({ params: { clientId: 'customer123' } })).to.not.throw();
     });
 
     it('should throw an Error on invalid configuration', function () {
-      expect(() => readConfig({ params: { bidders: 'There should be an array, not a string' } })).to.throw();
-      expect(() => readConfig({ params: { bidders: [] } })).to.throw();
-      expect(() => readConfig({ params: { customerId: 123 } })).to.throw();
+      expect(() => load({ params: { clientId: 123 } })).to.throw();
+      expect(() => load({ params: { clientId: 'abc.def' } })).to.throw();
+      expect(() => load({ params: { clientId: '1' } })).to.throw();
+      expect(() => load({ params: { clientId: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ' } })).to.throw();
     });
 
-    it('should insert external script element', () => {
-      injectHumanSecurityScript({ });
+    it('should insert implementation script', () => {
+      load({ });
 
       expect(loadExternalScriptStub.calledOnce).to.be.true;
 
       const args = loadExternalScriptStub.getCall(0).args;
-      expect(args[0]).to.be.equal(`${SCRIPT_URL}?h=example.com`);
+      expect(args[0]).to.be.equal(`${SCRIPT_URL}?r=example.com`);
       expect(args[1]).to.be.equal(SUBMODULE_NAME);
-      expect(args[2]).to.be.a('function');
+      expect(args[2]).to.be.equal(onImplLoaded);
       expect(args[3]).to.be.equal(null);
       expect(args[4]).to.be.deep.equal({ 'data-sid': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' });
     });
 
     it('should insert external script element with "customerId" info from config', () => {
-      injectHumanSecurityScript({ params: { customerId: 'ABC123' } });
+      load({ params: { clientId: 'customer123' } });
 
       expect(loadExternalScriptStub.calledOnce).to.be.true;
 
       const args = loadExternalScriptStub.getCall(0).args;
-      expect(args[0]).to.be.equal(`${SCRIPT_URL}?h=example.com&c=ABC123`);
+      expect(args[0]).to.be.equal(`${SCRIPT_URL}?r=example.com&c=customer123`);
+    });
+
+    it('should connect to the implementation script once it loads', function () {
+      load({ });
+
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+      expect(connectSpy.calledOnce).to.be.true;
+
+      const args = connectSpy.getCall(0).args;
+      expect(args[0]).to.haveOwnProperty('cmd'); // pbjs global
+      expect(args[0]).to.haveOwnProperty('que');
+      expect(args[1]).to.be.equal(onImplMessage);
     });
   });
 
   describe('Bid enrichment step', function () {
-    const fragmentToCompare = { info: 'bot+' };
+    const hmnsData = { 'v1': 'sometoken' };
+
+    let sandbox2;
     let callbackSpy;
-    beforeEach(function () {
-      callbackSpy = sandbox.spy();
+    let reqBidsConfig;
+    beforeEach(function() {
+      sandbox2 = sinon.sandbox.create();
+      callbackSpy = sandbox2.spy();
+      reqBidsConfig = { ortb2Fragments: { bidder: {}, global: {} } };
+    });
+    afterEach(function () {
+      sandbox2.restore();
     });
 
-    it('should add the default ext.hmns to global ortb2 when incorrect enrichment data comes from an external script', () => {
-      updateEnrichmentData({ hmns: 'bot', foo: 'bar' });
+    it('should add empty ext.hmns to global ortb2 when data is yet to be received from the impl script', () => {
+      load({ });
+
       onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
 
-      expect(reqBidsConfig.ortb2Fragments.global).to.have.property('ext');
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('ext');
       expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
-      expect(reqBidsConfig.ortb2Fragments.global.ext).to.not.have.property('foo');
     });
 
-    it('should add ext.hmns to global ortb2 when the bidders array is omitted in the configuration', () => {
-      updateEnrichmentData({ hmns: { info: 'bot+' } });
+    it('should add the default ext.hmns to global ortb2 when no "hmns" data was yet received', () => {
+      load({ });
+
+      onImplMessage({ type: 'info', data: 'not a hmns message' });
       onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
 
-      expect(reqBidsConfig.ortb2Fragments.global).to.have.property('ext');
-      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.property('hmns');
-      expect(reqBidsConfig.ortb2Fragments.global.ext.hmns).to.be.deep.equal(fragmentToCompare);
-
-      expect(reqBidsConfig.ortb2Fragments.bidder).to.be.deep.equal({});
       expect(callbackSpy.calledOnce).to.be.true;
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
     });
 
-    it('should add ext.hmns to global ortb2 when the bidders array is included in the configuration', () => {
-      updateEnrichmentData({ hmns: { info: 'bot+' } });
-      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: { bidders: ['bidderCode'] } }, {});
+    it('should add ext.hmns with received tokens to global ortb2 when the data was received', () => {
+      load({ });
 
-      const bidderCodeOrtb2Fragment = reqBidsConfig.ortb2Fragments.bidder['bidderCode'];
-      expect(bidderCodeOrtb2Fragment).to.not.be.undefined;
-      expect(bidderCodeOrtb2Fragment).to.have.property('ext');
-      expect(bidderCodeOrtb2Fragment.ext).to.have.property('hmns');
-      expect(bidderCodeOrtb2Fragment.ext.hmns).to.be.deep.equal(fragmentToCompare);
+      onImplMessage({ type: 'hmns', data: hmnsData });
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
 
-      expect(reqBidsConfig.ortb2Fragments.global).to.be.deep.equal({});
       expect(callbackSpy.calledOnce).to.be.true;
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals(hmnsData);
+    });
+
+    it('should update ext.hmns with new data', () => {
+      load({ });
+
+      onImplMessage({ type: 'hmns', data: { 'v1': 'should be overwritten' } });
+      onImplMessage({ type: 'hmns', data: hmnsData });
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
+
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals(hmnsData);
     });
   });
 
   describe('Sumbodule execution', function() {
+    let sandbox2;
     let submoduleStub;
-    beforeEach(function () {
-      submoduleStub = sandbox.stub(hook, 'submodule');
+    beforeEach(function() {
+      sandbox2 = sinon.sandbox.create();
+      submoduleStub = sandbox2.stub(hook, 'submodule');
+    });
+    afterEach(function () {
+      sandbox2.restore();
     });
 
     function getModule() {
-      registerHumanMediaGuardSubmodule();
+      main();
 
       expect(submoduleStub.calledOnceWith('realTimeData')).to.equal(true);
 
-      const registeredSubmoduleDefinition = submoduleStub.getCall(0).args[1];
-      expect(registeredSubmoduleDefinition).to.be.an('object');
-      expect(registeredSubmoduleDefinition).to.have.own.property('name', SUBMODULE_NAME);
-      expect(registeredSubmoduleDefinition).to.have.own.property('init').that.is.a('function');
-      expect(registeredSubmoduleDefinition).to.have.own.property('getBidRequestData').that.is.a('function');
+      const submoduleDef = submoduleStub.getCall(0).args[1];
+      expect(submoduleDef).to.be.an('object');
+      expect(submoduleDef).to.have.own.property('name', SUBMODULE_NAME);
+      expect(submoduleDef).to.have.own.property('init').that.is.a('function');
+      expect(submoduleDef).to.have.own.property('getBidRequestData').that.is.a('function');
 
-      return registeredSubmoduleDefinition;
+      return submoduleDef;
     }
 
     it('should register humansecurity RTD submodule provider', function () {
       getModule();
     });
 
-    it('should refuse initialization on invalid bidders configuration', function () {
+    it('should refuse initialization on invalid customer id configuration', function () {
       const { init } = getModule();
-      expect(init({ params: { bidders: [] }})).to.equal(false);
+      expect(init({ params: { clientId: 123 } })).to.equal(false);
       expect(loadExternalScriptStub.notCalled).to.be.true;
     });
 
-    it('should refuse initialization on invalid customer id configuration', function () {
+    it('should commence initialization on valid initialization', function () {
       const { init } = getModule();
-      expect(init({ params: { customerId: 123 }})).to.equal(false);
-      expect(loadExternalScriptStub.notCalled).to.be.true;
+      expect(init({ params: { clientId: 'customer123' } })).to.equal(true);
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+    });
+
+    it('should commence initialization on default initialization', function () {
+      const { init } = getModule();
+      expect(init({ })).to.equal(true);
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
     });
   });
 });

--- a/test/spec/modules/humansecurityRtdProvider_spec.js
+++ b/test/spec/modules/humansecurityRtdProvider_spec.js
@@ -111,39 +111,42 @@ describe('humansecurity RTD module', function () {
       sandbox2.restore();
     });
 
-    it('should add empty ext.hmns to global ortb2 when data is yet to be received from the impl script', () => {
+    it('should add empty device.ext.hmns to global ortb2 when data is yet to be received from the impl script', () => {
       load({ });
 
       onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
 
       expect(callbackSpy.calledOnce).to.be.true;
-      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('ext');
-      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('device');
+      expect(reqBidsConfig.ortb2Fragments.global.device).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.device.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
     });
 
-    it('should add the default ext.hmns to global ortb2 when no "hmns" data was yet received', () => {
+    it('should add the default device.ext.hmns to global ortb2 when no "hmns" data was yet received', () => {
       load({ });
 
       onImplMessage({ type: 'info', data: 'not a hmns message' });
       onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
 
       expect(callbackSpy.calledOnce).to.be.true;
-      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('ext');
-      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('device');
+      expect(reqBidsConfig.ortb2Fragments.global.device).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.device.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
     });
 
-    it('should add ext.hmns with received tokens to global ortb2 when the data was received', () => {
+    it('should add device.ext.hmns with received tokens to global ortb2 when the data was received', () => {
       load({ });
 
       onImplMessage({ type: 'hmns', data: hmnsData });
       onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
 
       expect(callbackSpy.calledOnce).to.be.true;
-      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('ext');
-      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals(hmnsData);
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('device');
+      expect(reqBidsConfig.ortb2Fragments.global.device).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.device.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals(hmnsData);
     });
 
-    it('should update ext.hmns with new data', () => {
+    it('should update device.ext.hmns with new data', () => {
       load({ });
 
       onImplMessage({ type: 'hmns', data: { 'v1': 'should be overwritten' } });
@@ -151,8 +154,9 @@ describe('humansecurity RTD module', function () {
       onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
 
       expect(callbackSpy.calledOnce).to.be.true;
-      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('ext');
-      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals(hmnsData);
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('device');
+      expect(reqBidsConfig.ortb2Fragments.global.device).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.device.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals(hmnsData);
     });
   });
 

--- a/test/spec/modules/humansecurityRtdProvider_spec.js
+++ b/test/spec/modules/humansecurityRtdProvider_spec.js
@@ -1,0 +1,159 @@
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
+import * as utils from '../../../src/utils.js';
+import * as hook from '../../../src/hook.js';
+
+import { __TEST__ } from '../../../modules/humansecurityRtdProvider.js';
+
+const {
+  SUBMODULE_NAME,
+  SCRIPT_URL,
+  updateEnrichmentData,
+  onGetBidRequestData,
+  readConfig,
+  injectHumanSecurityScript,
+  registerHumanMediaGuardSubmodule
+} = __TEST__;
+
+describe('humansecurity RTD module', function () {
+  let sandbox;
+  let ortb2Stub;
+
+  const win = Object.create({}, {
+    hostname: { value: 'example.com' }
+  });
+  const reqBidsConfig = {
+    ortb2Fragments: {
+      bidder: {},
+      global: {}
+    }
+  };
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(utils, 'getWindowLocation').returns(win);
+    sandbox.stub(utils, 'getWindowSelf').returns(win);
+    sandbox.stub(utils, 'generateUUID').returns('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+
+    ortb2Stub = sandbox.stub(reqBidsConfig, 'ortb2Fragments').value({bidder: {}, global: {}});
+  });
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  describe('Module initialization step', function () {
+    it('should accept valid configurations', function () {
+      expect(() => readConfig({})).to.not.throw();
+      expect(() => readConfig({ params: {} })).to.not.throw();
+      expect(() => readConfig({ params: { bidders: ['bidderCode'] } })).to.not.throw();
+      expect(() => readConfig({ params: { customerId: 'ABC123' } })).to.not.throw();
+    });
+
+    it('should throw an Error on invalid configuration', function () {
+      expect(() => readConfig({ params: { bidders: 'There should be an array, not a string' } })).to.throw();
+      expect(() => readConfig({ params: { bidders: [] } })).to.throw();
+      expect(() => readConfig({ params: { customerId: 123 } })).to.throw();
+    });
+
+    it('should insert external script element', () => {
+      injectHumanSecurityScript({ });
+
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+
+      const args = loadExternalScriptStub.getCall(0).args;
+      expect(args[0]).to.be.equal(`${SCRIPT_URL}?h=example.com`);
+      expect(args[1]).to.be.equal(SUBMODULE_NAME);
+      expect(args[2]).to.be.a('function');
+      expect(args[3]).to.be.equal(null);
+      expect(args[4]).to.be.deep.equal({ 'data-sid': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' });
+    });
+
+    it('should insert external script element with "customerId" info from config', () => {
+      injectHumanSecurityScript({ params: { customerId: 'ABC123' } });
+
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+
+      const args = loadExternalScriptStub.getCall(0).args;
+      expect(args[0]).to.be.equal(`${SCRIPT_URL}?h=example.com&c=ABC123`);
+    });
+  });
+
+  describe('Bid enrichment step', function () {
+    const fragmentToCompare = { info: 'bot+' };
+    let callbackSpy;
+    beforeEach(function () {
+      callbackSpy = sandbox.spy();
+    });
+
+    it('should add the default ext.hmns to global ortb2 when incorrect enrichment data comes from an external script', () => {
+      updateEnrichmentData({ hmns: 'bot', foo: 'bar' });
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
+
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
+      expect(reqBidsConfig.ortb2Fragments.global.ext).to.not.have.property('foo');
+    });
+
+    it('should add ext.hmns to global ortb2 when the bidders array is omitted in the configuration', () => {
+      updateEnrichmentData({ hmns: { info: 'bot+' } });
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
+
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.ext).to.have.property('hmns');
+      expect(reqBidsConfig.ortb2Fragments.global.ext.hmns).to.be.deep.equal(fragmentToCompare);
+
+      expect(reqBidsConfig.ortb2Fragments.bidder).to.be.deep.equal({});
+      expect(callbackSpy.calledOnce).to.be.true;
+    });
+
+    it('should add ext.hmns to global ortb2 when the bidders array is included in the configuration', () => {
+      updateEnrichmentData({ hmns: { info: 'bot+' } });
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: { bidders: ['bidderCode'] } }, {});
+
+      const bidderCodeOrtb2Fragment = reqBidsConfig.ortb2Fragments.bidder['bidderCode'];
+      expect(bidderCodeOrtb2Fragment).to.not.be.undefined;
+      expect(bidderCodeOrtb2Fragment).to.have.property('ext');
+      expect(bidderCodeOrtb2Fragment.ext).to.have.property('hmns');
+      expect(bidderCodeOrtb2Fragment.ext.hmns).to.be.deep.equal(fragmentToCompare);
+
+      expect(reqBidsConfig.ortb2Fragments.global).to.be.deep.equal({});
+      expect(callbackSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('Sumbodule execution', function() {
+    let submoduleStub;
+    beforeEach(function () {
+      submoduleStub = sandbox.stub(hook, 'submodule');
+    });
+
+    function getModule() {
+      registerHumanMediaGuardSubmodule();
+
+      expect(submoduleStub.calledOnceWith('realTimeData')).to.equal(true);
+
+      const registeredSubmoduleDefinition = submoduleStub.getCall(0).args[1];
+      expect(registeredSubmoduleDefinition).to.be.an('object');
+      expect(registeredSubmoduleDefinition).to.have.own.property('name', SUBMODULE_NAME);
+      expect(registeredSubmoduleDefinition).to.have.own.property('init').that.is.a('function');
+      expect(registeredSubmoduleDefinition).to.have.own.property('getBidRequestData').that.is.a('function');
+
+      return registeredSubmoduleDefinition;
+    }
+
+    it('should register humansecurity RTD submodule provider', function () {
+      getModule();
+    });
+
+    it('should refuse initialization on invalid bidders configuration', function () {
+      const { init } = getModule();
+      expect(init({ params: { bidders: [] }})).to.equal(false);
+      expect(loadExternalScriptStub.notCalled).to.be.true;
+    });
+
+    it('should refuse initialization on invalid customer id configuration', function () {
+      const { init } = getModule();
+      expect(init({ params: { customerId: 123 }})).to.equal(false);
+      expect(loadExternalScriptStub.notCalled).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New RTD provider

## Description of change

* We're submitting the HUMAN RTD Submodule for review;
* It enriches bid requests with additional bid-level signal, as described in the documentation (link)
It uses `device.ext.hmns` as the IVT signal collected is not considered "user data" and cannot be used to identify a user or a device; we request feedback on whether this is the right placement, and whether any other controls should be present to govern this location or data collected
* The Human Security RTD submodule offers pre-bid signal collection, aimed to improve real-time protection against all sorts of invalid traffic, such as bot-generated ad interactions or sophisticated ad fraud schemes. It generates Human Security token, which then can be consumed by vendors, sent within bid requests, and used for bot detection on the backend.

Contact email of the maintainer: [alexey@humansecurity.com](mailto:alexey@humansecurity.com)

## Other information
Documentation PR: https://github.com/cleanio/prebid.github.io/pull/1